### PR TITLE
Fix employee status toggle preserves past date assignements  - Add Sc…

### DIFF
--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -28,8 +28,9 @@ import CreateJobs from '../CreateJobs/CreateJobs';
 import EditForm from '../CreateJobs/EditForm';
 import JobHistory from '../JobHistory/JobHistory';
 import DragDrop from '../SaveDrag/SaveDrag';
-import Scheduling from '../Scheduling/Scheduling';
-import Trades from '../Trades/Trades';
+// import Scheduling from '../Scheduling/Scheduling';
+// import Trades from '../Trades/Trades';
+import SchedulingLayout from '../Scheduling/SchedulingLayout';
 
 import './App.css';
 
@@ -64,10 +65,9 @@ function App() {
 
           <ProtectedRoute exact path="/user">
             <DndProvider backend={HTML5Backend}>
-              <div className="parent-container">
-                <Scheduling />
-                <Trades />
-              </div>
+            <div className="parent-container">
+              <SchedulingLayout />
+            </div>
             </DndProvider>
           </ProtectedRoute>
 
@@ -110,10 +110,9 @@ function App() {
 
           <ProtectedRoute exact path="/scheduling">
             <DndProvider backend={HTML5Backend}>
-              <div className="parent-container">
-                <Scheduling />
-                <Trades />
-              </div>
+            <div className="parent-container">
+  <SchedulingLayout />
+</div>
             </DndProvider>
           </ProtectedRoute>
 

--- a/src/components/Scheduling/SchedulingLayout.jsx
+++ b/src/components/Scheduling/SchedulingLayout.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+import Scheduling from './Scheduling';
+import Trades from '../Trades/Trades';
+
+const SchedulingLayout = () => {
+  const isEditable = useSelector((state) => state.scheduleReducer.isEditable);
+
+  return (
+    <>
+      <Scheduling />
+      <Trades isEditable={isEditable} />
+    </>
+  );
+};
+
+export default SchedulingLayout;

--- a/src/components/Trades/Trades.jsx
+++ b/src/components/Trades/Trades.jsx
@@ -4,7 +4,7 @@ import UnionBox from './UnionBox';
 import unionColors from './UnionColors';
 import './Trades.css';
 
-const Trades = () => {
+const Trades = ({ isEditable}) => {
     const dispatch = useDispatch();
     const unions = useSelector((state) => state.unionReducer);
     const unionBox = useSelector((state) => state.unionBoxReducer);
@@ -41,6 +41,7 @@ const Trades = () => {
                             employees={union.employees}
                             color={unionColors[union.union_name]} 
                             moveEmployee={moveEmployee}
+                            isEditable={isEditable}
                         />
                     </div>
                 ))}

--- a/src/components/Trades/UnionBox.jsx
+++ b/src/components/Trades/UnionBox.jsx
@@ -3,7 +3,12 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useDrop } from 'react-dnd';
 import Employee from '../Scheduling/Employee';
 
-const UnionBox = ({ id, union_name, color }) => {
+const UnionBox = ({ 
+  id, 
+  union_name, 
+  color,
+  isEditable // NEW: Explicitly passed prop
+}) => {
     const dispatch = useDispatch();
     const selectedDate = useSelector((state) => state.scheduleReducer.selectedDate);
     const allEmployees = useSelector((state) => 
@@ -52,6 +57,13 @@ const UnionBox = ({ id, union_name, color }) => {
     // Get union number for styling
     const unionNumber = union_name.match(/^\d+/)?.[0];
     
+    // Filter employees based on editable state
+    const visibleEmployees = employees.filter(employee => {
+        // For past dates (not editable): show all employees who were in unions
+        // For current/future dates (editable): only show currently active employees
+        return isEditable ? employee.employee_status === true : true;
+    });
+    
     return (
         <div 
             ref={node => {
@@ -86,7 +98,7 @@ const UnionBox = ({ id, union_name, color }) => {
                 marginTop: '2px',
                 padding: '0px'
             }}> 
-                {employees.length === 0 ? (
+                {visibleEmployees.length === 0 ? (
                     <p className="no-employees" style={{ 
                         margin: '2px 0', 
                         fontSize: '11px', 
@@ -95,21 +107,19 @@ const UnionBox = ({ id, union_name, color }) => {
                         color: '#666'
                     }}>No employees assigned</p>
                 ) : (
-                    employees
-                        .filter(employee => employee.employee_status === true)
-                        .map((employee, index) => (
-                            <Employee
-                                key={employee.id}
-                                {...employee}
-                                id={employee.id} 
-                                className={`employee-name union-${unionNumber}`}
-                                name={`${employee.first_name} ${employee.last_name}`}
-                                union_id={id}
-                                union_name={union_name}
-                                current_location="union"
-                                index={index}
-                            />
-                        ))
+                    visibleEmployees.map((employee, index) => (
+                        <Employee
+                            key={`${employee.id}-${index}`}
+                            {...employee}
+                            id={employee.id} 
+                            className={`employee-name union-${unionNumber}`}
+                            name={`${employee.first_name} ${employee.last_name}`}
+                            union_id={id}
+                            union_name={union_name}
+                            current_location="union"
+                            index={index}
+                        />
+                    ))
                 )}
             </div>
         </div>


### PR DESCRIPTION
Fix employee status toggle preserves past date assignments

- Add SchedulingLayout wrapper component to coordinate isEditable prop
- Update ProjectBox and UnionBox to respect past vs current date filtering
- Past dates now show all historically assigned employees
- Current dates only show active employees
- Resolves issue where toggling employee status lost historical assignments